### PR TITLE
feat: Implement PDF loader for ingestion

### DIFF
--- a/scripts/ingestion/__init__.py
+++ b/scripts/ingestion/__init__.py
@@ -1,7 +1,9 @@
 from .docx_loader import load_docx
 from .email_loader import load_eml
+from .pdf import load_pdf # Add this import
 
 LOADER_REGISTRY = {
     ".docx": load_docx,
     ".eml": load_eml,
+    ".pdf": load_pdf, # Add this mapping
 }

--- a/scripts/ingestion/models.py
+++ b/scripts/ingestion/models.py
@@ -4,3 +4,6 @@ from dataclasses import dataclass
 class RawDoc:
     content: str
     metadata: dict
+
+class UnsupportedFileError(Exception):
+    pass

--- a/scripts/ingestion/pdf.py
+++ b/scripts/ingestion/pdf.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+import pdfplumber
+from pdfminer.pdfdocument import PDFPasswordIncorrect
+from pdfminer.pdfparser import PDFSyntaxError
+from pdfplumber.utils.exceptions import PdfminerException # Corrected import
+from scripts.ingestion.models import RawDoc, UnsupportedFileError
+# No hashlib needed as UID is not part of RawDoc
+
+def load_pdf(path: str | Path) -> RawDoc:
+    if not isinstance(path, Path):
+        path = Path(path)
+
+    try:
+        # Attempt to open the PDF. This can raise FileNotFoundError or PdfminerException (wrapping others).
+        with pdfplumber.open(path) as pdf:
+            # These operations might raise PDFPasswordIncorrect or PDFSyntaxError directly,
+            # or other pdfminer errors if not caught by pdfplumber.open's wrapper.
+            _ = len(pdf.pages)
+            _ = pdf.metadata
+
+            if not pdf.pages: # Check if there are any pages
+                raise UnsupportedFileError(f"No pages found in PDF: {path}")
+
+            page_texts = []
+            for page in pdf.pages:
+                text = page.extract_text()
+                if text: # Only append if text was extracted
+                    page_texts.append(text.strip()) # Also strip whitespace from individual page texts
+
+            if not page_texts: # No text extracted from any page
+                raise UnsupportedFileError(f"No extractable text found in PDF: {path}")
+
+            full_text = "\n\n".join(page_texts)
+
+            # pdfplumber's metadata keys can be 'Title', 'Author', 'CreationDate', 'ModDate'
+            # We use .get() to gracefully handle missing keys, returning None.
+            # The dates are typically strings and are stored as such.
+            metadata = {
+                "source_path": str(path.resolve()), # Store absolute path as string
+                "title": pdf.metadata.get("Title"),
+                "author": pdf.metadata.get("Author"),
+                "created": pdf.metadata.get("CreationDate"), # Store as string or None
+                "modified": pdf.metadata.get("ModDate"),   # Store as string or None
+                "num_pages": len(pdf.pages),
+            }
+
+            return RawDoc(content=full_text, metadata=metadata)
+
+    except FileNotFoundError as e: # If the file itself is not found
+        raise # The test expects FileNotFoundError to be propagated.
+
+    except PDFPasswordIncorrect as e: # If specifically password protected (potentially from pdf.pages etc.)
+        raise UnsupportedFileError(f"PDF {path} is encrypted and requires a password.") from e
+
+    except PDFSyntaxError as e: # If PDF is corrupted (potentially from pdf.pages etc.)
+        raise UnsupportedFileError(f"Failed to parse PDF {path}, it might be corrupted: {e}") from e
+
+    except PdfminerException as e: # Catch exceptions wrapped by pdfplumber.open()
+        # Check the wrapped exception type
+        if isinstance(e.args[0], PDFPasswordIncorrect):
+            raise UnsupportedFileError(f"PDF {path} is encrypted and requires a password.") from e
+        elif isinstance(e.args[0], PDFSyntaxError): # This covers general parsing errors
+            raise UnsupportedFileError(f"Failed to parse PDF {path}, it might be corrupted: {e.args[0]}") from e
+        else: # Other errors from pdfminer wrapped by PdfminerException
+            raise UnsupportedFileError(f"An unexpected PDF processing error occurred with {path}: {e.args[0]}") from e
+
+    except UnsupportedFileError: # If we raised it ourselves (e.g. no text, no pages)
+        raise
+
+    except Exception as e: # For any other truly unexpected errors
+        raise UnsupportedFileError(f"An unexpected error occurred while processing PDF {path}: {e}") from e

--- a/tests/fixtures/pdf/encrypted.pdf
+++ b/tests/fixtures/pdf/encrypted.pdf
@@ -1,0 +1,75 @@
+%PDF-1.3
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (\032\206\265\332\011\356\247\030h) /CreationDate (?\322\350\204B\266\370[*\355\346\303\306\317\275\\\025\335<\321.\232L) /Creator (\)\215\252\333\002\367\204\014y\377\207\264\261\335\301\001\\\237m\204g\212F\262\233\232\037\237\251rGU\241\(qG,\)U*\255) /Keywords () /ModDate (?\322\350\204B\266\370[*\355\346\303\306\317\275\\\025\335<\321.\232L) /Producer (\)\215\252\333\002\367\204\014y\377\207\264\261\335\301\001\\\237m\204g\212F\262\233\232\037\237\251rGU\241\(qG,\)U*\255)
+  /Subject (\016\206\251\304\025\340\241\013r\272\263) /Title (\016\206\256\335\004\357\255\011) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Filter /Standard /O <842E9696ECDF13A829F3B63C5B9614CC6254B7E0385B247BAB90A508179C0340> /P -4 /R 2 /U <3B6C9AAB489544C7BD952A708795F4AD915F4E2E894EDCA97A2A19C75179E6E2> /V 1
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 126
+>>
+stream
+\xf1ʳw\x96I\xc0>k#lAnb`EV\x92؈\xefc%\xfb\xcd¤\xad|;\xa6q)a\xfe\xfari\xbb\xe2B40\xda \xd2!S\x9f=\xe8\xac\xd7Y2\xe9\xfa\x8f\xfb\xed\x8aq\xbe	C\xf3\xbak\x86N&\xf9\xdeX2\xaf\xb10\x98\x8a\xe1\xfc%u\x82Z\x8c\xbb\xbao\xe1Y!J\xb1\xab\x8e\x9f\xa8G\x9c\xfa\xf9z"txendstream
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000073 00000 n
+0000000104 00000 n
+0000000211 00000 n
+0000000414 00000 n
+0000000482 00000 n
+0000001106 00000 n
+0000001301 00000 n
+0000001360 00000 n
+trailer
+<<
+/Encrypt 6 0 R
+/ID
+[<e90c3b010ba1660b154d1786f405c703><e90c3b010ba1660b154d1786f405c703>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 9
+>>
+startxref
+1576
+%%EOF

--- a/tests/fixtures/pdf/no_text.pdf
+++ b/tests/fixtures/pdf/no_text.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250612131204+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250612131204+00'00') /Producer (ReportLab PDF Library - www.reportlab.com)
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 59
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_PP$O!3^,C5Q~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f
+0000000073 00000 n
+0000000104 00000 n
+0000000211 00000 n
+0000000414 00000 n
+0000000482 00000 n
+0000000778 00000 n
+0000000837 00000 n
+trailer
+<<
+/ID
+[<23f65131de2743e5f8c409eb394fddae><23f65131de2743e5f8c409eb394fddae>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+985
+%%EOF

--- a/tests/fixtures/pdf/simple.pdf
+++ b/tests/fixtures/pdf/simple.pdf
@@ -1,0 +1,87 @@
+%PDF-1.3
+%\x93\x8c\x8b\x9e ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>>
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (Test Author) /CreationDate (D:20250612131155+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250612131155+00'00') /Producer (ReportLab PDF Library - www.reportlab.com)
+  /Subject (unspecified) /Title (Simple Test PDF) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 2 /Kids [ 3 0 R 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 107
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90MjG^2,FS#<R;#na=L?lU4U>U<!>WP9neZ[Kb,ht"pHUZB?V%O~>endstream
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 107
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90MjG^2,FS#<R;#na=L?lU4U>U<!=L09neZ[Kb,ht"pHUZBA4*_~>endstream
+endobj
+xref
+0 10
+0000000000 65535 f
+0000000073 00000 n
+0000000104 00000 n
+0000000211 00000 n
+0000000414 00000 n
+0000000617 00000 n
+0000000685 00000 n
+0000000990 00000 n
+0000001055 00000 n
+0000001252 00000 n
+trailer
+<<
+/ID
+[<e52615a2779e5bf0bcd59f49a878e828><e52615a2779e5bf0bcd59f49a878e828>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 10
+>>
+startxref
+1449
+%%EOF

--- a/tests/test_pdf_loader.py
+++ b/tests/test_pdf_loader.py
@@ -1,0 +1,114 @@
+import pytest
+from pathlib import Path
+from scripts.ingestion.pdf import load_pdf
+from scripts.ingestion.models import RawDoc, UnsupportedFileError
+# If pdfplumber is needed for test setup (e.g. creating test PDFs), it should be imported as 'import pdfplumber'
+
+# Define fixture paths (adjust if your fixture directory is different)
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "pdf"
+SIMPLE_PDF = FIXTURES_DIR / "simple.pdf"
+ENCRYPTED_PDF = FIXTURES_DIR / "encrypted.pdf"
+NO_TEXT_PDF = FIXTURES_DIR / "no_text.pdf"
+
+# Helper to create a simple PDF for testing (if not providing actual files)
+# For a more robust solution, you would typically add pre-made fixture files to your repo
+# For this subtask, we will try to create them if they don't exist.
+def _create_test_pdfs_if_not_exist():
+    FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+
+    if not SIMPLE_PDF.exists():
+        try:
+            import pdfplumber
+            from reportlab.pdfgen import canvas
+            c = canvas.Canvas(str(SIMPLE_PDF))
+            c.setTitle("Simple Test PDF")
+            c.setAuthor("Test Author")
+            # Page 1
+            c.drawString(100, 750, "This is page 1.")
+            c.showPage()
+            # Page 2
+            c.drawString(100, 750, "This is page 2.")
+            c.showPage()
+            c.save()
+        except ImportError:
+            print("ReportLab is not installed. Skipping creation of simple.pdf. Please create it manually.")
+            # Fallback: create an empty file so the path exists
+            SIMPLE_PDF.touch()
+
+
+    if not ENCRYPTED_PDF.exists():
+        try:
+            import pdfplumber
+            from reportlab.pdfgen import canvas
+            c = canvas.Canvas(str(ENCRYPTED_PDF))
+            c.drawString(100, 750, "This is an encrypted document.")
+            # Standard encryption with user password "password"
+            c.setEncrypt("password")
+            c.showPage()
+            c.save()
+        except ImportError:
+            print("ReportLab is not installed. Skipping creation of encrypted.pdf. Please create it manually.")
+            ENCRYPTED_PDF.touch()
+
+    if not NO_TEXT_PDF.exists():
+        try:
+            import pdfplumber
+            from reportlab.pdfgen import canvas
+            c = canvas.Canvas(str(NO_TEXT_PDF))
+            # Add an image or just save an empty page to simulate no text
+            c.showPage() # Empty page
+            c.save()
+        except ImportError:
+            print("ReportLab is not installed. Skipping creation of no_text.pdf. Please create it manually.")
+            NO_TEXT_PDF.touch()
+
+_create_test_pdfs_if_not_exist()
+
+
+class TestPDFLoader:
+    def test_load_simple_pdf_success(self):
+        # This test assumes simple.pdf was created successfully by the helper or exists
+        if not SIMPLE_PDF.exists() or SIMPLE_PDF.stat().st_size == 0:
+             pytest.skip("simple.pdf fixture not available for testing.")
+
+        doc = load_pdf(SIMPLE_PDF)
+        assert isinstance(doc, RawDoc)
+        assert doc.content == "This is page 1.\n\nThis is page 2."
+        assert doc.metadata["source_path"] == str(SIMPLE_PDF.resolve())
+        assert doc.metadata["title"] == "Simple Test PDF"
+        assert doc.metadata["author"] == "Test Author"
+        assert doc.metadata["num_pages"] == 2
+        # Created and modified dates are harder to assert precisely without knowing the test environment
+        # So, we'll just check if they exist for now, or are None if pdfplumber couldn't get them.
+        assert "created" in doc.metadata
+        assert "modified" in doc.metadata
+
+    def test_load_encrypted_pdf_raises_error(self):
+        if not ENCRYPTED_PDF.exists() or ENCRYPTED_PDF.stat().st_size == 0:
+            pytest.skip("encrypted.pdf fixture not available for testing.")
+
+        with pytest.raises(UnsupportedFileError, match="is encrypted and requires a password"):
+            load_pdf(ENCRYPTED_PDF)
+
+    def test_load_no_text_pdf_raises_error(self):
+        # This test assumes no_text.pdf was created or exists
+        if not NO_TEXT_PDF.exists() or NO_TEXT_PDF.stat().st_size == 0:
+             pytest.skip("no_text.pdf fixture not available for testing.")
+
+        with pytest.raises(UnsupportedFileError, match="No extractable text found"):
+            load_pdf(NO_TEXT_PDF)
+
+    def test_load_non_existent_pdf_raises_error(self):
+        with pytest.raises(FileNotFoundError): # pdfplumber.open raises FileNotFoundError
+            load_pdf(Path("non_existent_file.pdf"))
+
+    def test_load_corrupted_pdf_raises_error(self):
+        # Create a dummy corrupted file
+        corrupted_pdf_path = FIXTURES_DIR / "corrupted.pdf"
+        with open(corrupted_pdf_path, "w") as f:
+            f.write("This is not a PDF content.")
+
+        with pytest.raises(UnsupportedFileError, match="Failed to parse PDF"):
+            load_pdf(corrupted_pdf_path)
+
+        corrupted_pdf_path.unlink() # Clean up


### PR DESCRIPTION
I've added a new PDF loader (`load_pdf` function) to handle .pdf files within the ingestion framework.

Key changes:
- I created `scripts/ingestion/pdf.py` containing the `load_pdf` function.
- `load_pdf` uses `pdfplumber` to extract text and metadata (title, author, creation date, modification date, number of pages) from PDF files.
- Page texts are concatenated with "\n\n".
- Extracted information is returned as a `RawDoc` object.
- I added `UnsupportedFileError` to `scripts/ingestion/models.py` for custom error handling.
- `load_pdf` raises `UnsupportedFileError` for encrypted PDFs, PDFs with no extractable text, or corrupted/unparsable PDFs.
- I integrated `load_pdf` into the `LOADER_REGISTRY` in `scripts/ingestion/__init__.py` for the ".pdf" extension.
- I added comprehensive unit tests in `tests/test_pdf_loader.py` covering:
    - Successful parsing of standard PDFs.
    - Handling of encrypted PDFs.
    - Handling of PDFs with no extractable text.
    - Handling of non-existent or corrupted PDF files.
- The error handling in `load_pdf` was refined during testing to correctly map underlying library exceptions to `UnsupportedFileError`.